### PR TITLE
Updates to command logic

### DIFF
--- a/lib/lacquer/cache_utils.rb
+++ b/lib/lacquer/cache_utils.rb
@@ -28,12 +28,12 @@ module Lacquer
         case Lacquer.configuration.job_backend
         when :delayed_job
           require 'lacquer/delayed_job_job'
-          Delayed::Job.enqueue(Lacquer::DelayedJobJob.new('url.purge ' << path))
+          Delayed::Job.enqueue(Lacquer::DelayedJobJob.new(path))
         when :resque
           require 'lacquer/resque_job'
-          Resque.enqueue(Lacquer::ResqueJob, 'url.purge ' << path)
+          Resque.enqueue(Lacquer::ResqueJob, path)
         when :none
-          Varnish.new.purge('url.purge ' << path)
+          Varnish.new.purge(path)
         end
       end
     end

--- a/lib/lacquer/resque_job.rb
+++ b/lib/lacquer/resque_job.rb
@@ -3,7 +3,7 @@ module Lacquer
     @queue = :lacquer
   
     def self.perform(command)
-      VarnishInterface.new.purge(command)
+      Varnish.new.purge(command)
     end
   end
 end

--- a/spec/lacquer/cache_utils_spec.rb
+++ b/spec/lacquer/cache_utils_spec.rb
@@ -46,7 +46,7 @@ describe "Lacquer" do
         Lacquer.configuration.default_ttl = 1.week
 
         @controller.set_default_cache_ttl
-        @controller.should_receive(:expires_in).with(1.week, :public => true)
+        @controller.should_receive(:expires_in).with(1.week, :public => true, :private => false)
         @controller.send_cache_control_headers
       end
     end
@@ -56,7 +56,7 @@ describe "Lacquer" do
         Lacquer.configuration.enable_cache = true
 
         @controller.set_cache_ttl(10.week)
-        @controller.should_receive(:expires_in).with(10.week, :public => true)
+        @controller.should_receive(:expires_in).with(10.week, :public => true, :private => false)
         @controller.send_cache_control_headers
       end
     end

--- a/spec/lacquer/varnish_spec.rb
+++ b/spec/lacquer/varnish_spec.rb
@@ -128,5 +128,10 @@ Closing CLI connection
       @telnet_mock.stub!(:cmd).and_yield('200')
       Lacquer::Varnish.new.purge('/').should be(true)
     end
+    
+    it "should send a valid purge command" do
+      @telnet_mock.should_receive(:cmd).with("url.purge /\nquit\n").once
+      Lacquer::Varnish.new.purge("/")
+    end      
   end
 end


### PR DESCRIPTION
Hi There,

I noticed on one of my sites that the purge commands were being repeated (i.e. `purge.url purge.url /some/url/here`).
I have fixed this up and updated the spec to reflect changes. The commit ref is ae8d0c48e77cf6c50939971a6446cc95e6064d1a.

Hope this helps,
Matthew
