### PR TITLE
Fixed a small typo with double concatenation operators (+ and <<).

### DIFF
--- a/lib/lacquer/varnish.rb
+++ b/lib/lacquer/varnish.rb
@@ -14,7 +14,7 @@ module Lacquer
     # Sends the command 'url.purge *path*'
     def purge(*paths)
       paths.all? do |path|
-        send_command(Lacquer.configuration.purge_command + " " + << path.gsub('\\', '\\\\\\')).all? do |result|
+        send_command(Lacquer.configuration.purge_command + " " + path.gsub('\\', '\\\\\\')).all? do |result|
           result =~ /200/
         end
       end


### PR DESCRIPTION
Pulled the latest gem and got this error:

```
.../gems/lacquer-0.5.2/lib/lacquer/varnish.rb:17: syntax error, unexpected tLSHFT
...ration.purge_command + " " + << path.gsub('\\', '\\\\\\')).a...
```
