### PR TITLE
Fix an extra newline in the auth challenge construction

### DIFF
--- a/lib/lacquer/varnish.rb
+++ b/lib/lacquer/varnish.rb
@@ -47,7 +47,6 @@ module Lacquer
               digest << salt
               digest << "\n"
               digest << server[:secret]
-              digest << "\n"
               digest << salt
               digest << "\n"
 


### PR DESCRIPTION
Quoting the Varnish CLI docs (https://www.varnish-cache.org/trac/wiki/CLI), the auth challenge reply has a small bug:

```
The authenticator is calculated by applying the SHA256 function to the following byte sequence:

Challenge string
Newline (0x0a) character.
Contents of the secret file
Challenge string
Newline (0x0a) character. 
```

The current implementation has an extra newline between the secret and the salt.  This is probably masked by an oft-occurring extra newline most people's editors put in a file that just has one line.  If you use an automated tool like chef to write out this file from a string, the extra newline isn't there and you are left wondering why your perfectly equal strings result in an auth failure.  :)
