### PR TITLE
update openssl digest call

### DIFF
--- a/lib/lacquer/varnish.rb
+++ b/lib/lacquer/varnish.rb
@@ -43,7 +43,7 @@ module Lacquer
                 raise VarnishError, "Bad authentication request"
               end
 
-              digest = OpenSSL::Digest::Digest.new('sha256')
+              digest = OpenSSL::Digest.new('sha256')
               digest << salt
               digest << "\n"
               digest << server[:secret]


### PR DESCRIPTION
OpenSSL::Digest::Digest has been deprecated and throws warning. https://github.com/ruby/ruby/blob/ruby_1_8_7/ext/openssl/lib/openssl/digest.rb#L51