### PR TITLE
fix deprecation warning

### DIFF
--- a/lib/lacquer/varnish.rb
+++ b/lib/lacquer/varnish.rb
@@ -43,7 +43,7 @@ module Lacquer
                 raise VarnishError, "Bad authentication request"
               end
 
-              digest = OpenSSL::Digest::Digest.new('sha256')
+              digest = OpenSSL::Digest.new('sha256')
               digest << salt
               digest << "\n"
               digest << server[:secret]


### PR DESCRIPTION
This fixes the `OpenSSL::Digest::Digest` deprecation warning.